### PR TITLE
Keep parse_regex_options from always returning 0

### DIFF
--- a/tdt/actions/utils.py
+++ b/tdt/actions/utils.py
@@ -609,4 +609,4 @@ def parse_regex_options(filter_obj: dict):
             _f = getattr(re, _regex_opt.split(".")[1])
             _reg_flags = _flags | _f
 
-    return _flags
+    return _reg_flags


### PR DESCRIPTION
The wrong variable was being returned from parse_regex_options, causing the regex options to never apply to the filter content.